### PR TITLE
use glm to replace deprecated glu functions

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -54,9 +54,16 @@ solution "MMDTestSolution"
          defines { 'NOMINMAX', '_LARGEFILE_SOURCE', '_FILE_OFFSET_BITS=64' }
 
       -- Linux specific
-      if (os.is("linux")) then
+      configuration { "linux", "gmake" }
          defines { '_LARGEFILE_SOURCE', '_FILE_OFFSET_BITS=64' }
-      end
+         defines { 'ENABLE_GLM' }
+         -- defines { 'ENABLE_BULLET' }
+         -- includedirs { "./extlibs/bullet/bullet3/src" }
+         -- libdirs { "./extlibs/bullet/bullet3/src/BulletDynamics"
+         --         , "./extlibs/bullet/bullet3/src/BulletCollision" 
+         --         , "./extlibs/bullet/bullet3/src/LinearMath" } 
+         -- links { "BulletDynamics", "BulletCollision", "LinearMath" }
+         links { "GL", "glut" }
 
       configuration "Debug"
          defines { "DEBUG" } -- -DDEBUG

--- a/premake4.lua
+++ b/premake4.lua
@@ -1,5 +1,10 @@
+newoption {
+   trigger = "with-glm",
+   description = "Build with GLM replacement for gluPerspecive and gluLookat"
+}
+
 sources = {
-	"viewer_main.cc",
+   "viewer_main.cc",
    "trackball.cpp"
    }
 
@@ -56,7 +61,9 @@ solution "MMDTestSolution"
       -- Linux specific
       configuration { "linux", "gmake" }
          defines { '_LARGEFILE_SOURCE', '_FILE_OFFSET_BITS=64' }
-         defines { 'ENABLE_GLM' }
+         if _OPTIONS["with-glm"] then
+             defines { 'ENABLE_GLM' }
+         end
          -- defines { 'ENABLE_BULLET' }
          -- includedirs { "./extlibs/bullet/bullet3/src" }
          -- libdirs { "./extlibs/bullet/bullet3/src/BulletDynamics"

--- a/trackball.cpp
+++ b/trackball.cpp
@@ -50,7 +50,7 @@
  * Gavin Bell
  */
 #include <math.h>
-#include "TrackBall.h"
+#include "trackball.h"
 
 /*
  * This size should really be based on the distance from the center of

--- a/viewer_main.cc
+++ b/viewer_main.cc
@@ -751,7 +751,6 @@ void display() {
   // set_orthoview_pass(width, height);
 
   glMatrixMode(GL_MODELVIEW);
-  glLoadIdentity();
 
 #ifdef ENABLE_GLM
   glm::vec3 origin(view_org[0], view_org[1], view_org[2]);
@@ -760,6 +759,7 @@ void display() {
   glm::mat4 model_view = glm::lookAt(origin, target, up);
   glLoadMatrixf(glm::value_ptr(model_view));
 #else
+  glLoadIdentity();
   gluLookAt(view_org[0], view_org[1], view_org[2], view_tgt[0], view_tgt[1],
             view_tgt[2], 0, 1, 0); /* Y up */
 #endif
@@ -794,7 +794,6 @@ void reshape(int w, int h) {
   glMatrixMode(GL_PROJECTION);
 #ifdef ENABLE_GLM
   glm::mat4 projection = glm::perspective(45.0f, (float)w / (float)h, 0.1f, 50.0f);
-  glMatrixMode(GL_PROJECTION);
   glLoadMatrixf(glm::value_ptr(projection));
 #else
   glLoadIdentity();

--- a/viewer_main.cc
+++ b/viewer_main.cc
@@ -30,6 +30,12 @@
 // image loader
 //#include "stb_image.c"
 
+#ifdef ENABLE_GLM
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#endif
+
 using namespace mmd;
 
 #define WINDOW_WIDTH 800
@@ -747,8 +753,16 @@ void display() {
   glMatrixMode(GL_MODELVIEW);
   glLoadIdentity();
 
+#ifdef ENABLE_GLM
+  glm::vec3 origin(view_org[0], view_org[1], view_org[2]);
+  glm::vec3 target(view_tgt[0], view_tgt[1], view_tgt[2]);
+  glm::vec3 up(0, 1, 0);
+  glm::mat4 model_view = glm::lookAt(origin, target, up);
+  glLoadMatrixf(glm::value_ptr(model_view));
+#else
   gluLookAt(view_org[0], view_org[1], view_org[2], view_tgt[0], view_tgt[1],
             view_tgt[2], 0, 1, 0); /* Y up */
+#endif
 
   glMultMatrixf(&(m[0][0]));
 
@@ -778,8 +792,14 @@ void display() {
 void reshape(int w, int h) {
   glViewport(0, 0, w, h);
   glMatrixMode(GL_PROJECTION);
+#ifdef ENABLE_GLM
+  glm::mat4 projection = glm::perspective(45.0f, (float)w / (float)h, 0.1f, 50.0f);
+  glMatrixMode(GL_PROJECTION);
+  glLoadMatrixf(glm::value_ptr(projection));
+#else
   glLoadIdentity();
   gluPerspective(45.0f, (float)w / (float)h, 0.1f, 50.0f);
+#endif
   glMatrixMode(GL_MODELVIEW);
   glLoadIdentity();
 


### PR DESCRIPTION
Dear Syoyo Fujita,
Please accept my pull request.
I made the following changes to make the project buildable on my end:
* Corrected typo: "TrackBall.h" doesn't exist
* Use glm to replace deprecated glu functions: gluPerspective, gluLookat

I think this might be useful for others who share a similar setup.
My system: Ubuntu 16.04 + glm 0.9.7.2 + bullet3

Thanks,
onlyuser